### PR TITLE
Add scenario tasks to three personas

### DIFF
--- a/personas/Alex_dotnet_maui.md
+++ b/personas/Alex_dotnet_maui.md
@@ -23,11 +23,14 @@ Alex is most familiar with Visual Studio and plans to use it as the IDE. Alex wo
 ## Scenario tasks
 
 1. Alex needs to install and set up a .NET MAUI development environment.
-
-2. TBD
+1. Alex needs to create the Windows app first but wants to ensure that any features developed can easily be adapted to the iOS and Android platforms.
+1. Alex needs to test the Windows, iOS and Android apps while developing with Visual Studio on Windows.
+1. TBD
 
 ## Advanced scenarios
 
+1. Alex wants the app to call some APIs deployed to an Azure App Service. The app will need to use the current user's Microsoft Entra ID account to authenticate when making the calls. There will likely be many API calls made as the users are using the app, and Alex only wants to prompt the users to authenticate once during their session. The authentication method needs to work on every target platform.
+1. Alex wants to migrate one of their team's existing Xamarin.Forms apps to .NET MAUI. The current app only targets iOS and Android, and Alex's team wants the .NET MAUI app to also have a Windows version.
 1. TBD
 
 ## Additional Demographics

--- a/personas/Jamie_winui_winappsdk.md
+++ b/personas/Jamie_winui_winappsdk.md
@@ -27,10 +27,9 @@ Jamie is most familiar with Visual Studio and plans to use it as the IDE. Jamie 
 ## Scenario tasks
 
 1. Jamie needs to learn about the differences between WinUI 2 and WinUI 3 and how those differences will affect her normal workflow and bookmarked documentation references. She is used to working with the standalone WinUI 2 NuGet package in a UWP app environment. She uses C# and C++ in her project code and has used XAML islands in past projects. She needs to learn how to create a new project template that uses WinUI 3 and Windows App SDK. She doesn't quite understand how Windows App SDK differs from Windows SDK either. She has not yet installed Windows App SDK and has been using an older version of Visual Studio 2019.
-
-2. Now that Jamie understands the difference between WinUI 2 and WinUI 3, has installed the Windows App SDK, and has created a project template inside Visual Studio, she needs to know how to design a user interface layout with modern controls.
-
-3. TBD
+1. Now that Jamie understands the difference between WinUI 2 and WinUI 3, has installed the Windows App SDK, and has created a project template inside Visual Studio, she needs to know how to design a user interface layout with modern controls.
+1. Jamie's team has some shared .NET 8 libraries that will soon be updated to target .NET 9. Jamie wants to ensure that any new WinUI apps they create can use these shared libraries to maximize code reuse. She needs to know how to reference these shared libraries in her new WinUI 3 project.
+1. TBD
 
 ## Advanced scenarios
 

--- a/personas/Morgan_wpf_ai.md
+++ b/personas/Morgan_wpf_ai.md
@@ -21,10 +21,9 @@ Morgan is most familiar with C# and Python. He uses Visual Studio as his IDE. Ja
 ## Scenario tasks
 
 1. Morgan needs to learn about how to integrate new Windows AI features into his existing WPF apps.
-
-2. TBD
-
-3. TBD
+1. Most of the legacy WPF apps at Morgan's company target the .NET Framework version of WPF. Morgan needs to learn how to update one of these legacy apps to target .NET 8 or later to improve its performance and security, as well as leverage some of the companies shared class libraries that currently target .NET 8.
+1. After updating their WPF app to .NET 8, it needs to consume some Windows App SDK APIs. Morgan isn't sure if this is possible and wants to learn more about how they can do this.
+1. TBD
 
 ## Advanced scenarios
 


### PR DESCRIPTION
I added scenario tasks to three of the personas. Let me know what you think of these. All suggestions/edits welcome.

I also have some questions about some of the personas. I'll list those here for discussion:

**.NET MAUI Persona (Alex)**

1. For this part of the "Goals and challenges", what is intended with this statement?

   > "Alex also wants to ensure the compatibility of features in the web browsers used by IT admins and local devices (Windows and Mac) by the employees of the Enterprise company that they work for."

1. Is Alex hoping to deploy via the web? Or does his company eventually want to transition to using a web app instead of MAUI? Or is the MAUI app going to contain a WebView control with some web content that needs to maintain compatibility?
1. MAUI itself doesn't run in browsers. If that's a goal, we could update this to be somebody using Uno Platform or Avalonia UI. Both of those can target Windows, iOS, Android, Linux, and WebAssembly.

**Native dev WinUI Persona (Jamie)**

Should we provide more specifics around Jamie's background in Windows development? Someone familiar with Win32/C++ or WinForms development will need different learning material than somebody who has done WPF or UWP development. UWP will need the least help moving forward to WinUI, and this statement "Jamie has found it challenging to use WinUI 3 so far due to its different set of core types" would not be true. UWP and WinUI have nearly the same types but with different namespaces.

**UWP migration persona (Taylor)**

I'll need to think about this one. Migrating away from UWP will have platform compatibility implications. This will be a good one because I don't think our docs address this story at all. I'd probably recommend they do a Unity re-write of their games.